### PR TITLE
Fix multiple click binds

### DIFF
--- a/context-menu.js
+++ b/context-menu.js
@@ -59,14 +59,13 @@ function ContextMenu(contextContainerID, menuItemClickCallback, options)
             }
         }
 
+        //Remove the click event otherwise a new one keep getting created, so an additional call event will be called
+        //each time the menu opens and closes
+        contextMenu.find("ul > li").unbind("click");
         contextMenu.find("ul > li").click(function(){
             if (!$(this).hasClass("disabled")) {
                 menuItemClickCallback($(this), parent);
                 contextMenu.hide();
-
-                //Remove the click event otherwise a new one keep getting created, so an additional call event will be called
-                //each time the menu opens and closes
-                contextMenu.find("ul > li").unbind("click");
             }
         });
 


### PR DESCRIPTION
Hi,

thank you for this very useful little library. I just found one bug. I am kind of surprised that no one noticed it eralier.

If you open one context menu and then click on another 3-dot menu and then select some option, the listener will execute twice.
Seems like removing all click binds prior to adding new one is sufficent fix. 

Earlier solution did not counted with possibility of just clicking elsewhere on the page, thus not executing the unbind function.